### PR TITLE
Working API request for version queries

### DIFF
--- a/OSMPythonTools/api.py
+++ b/OSMPythonTools/api.py
@@ -47,7 +47,7 @@ class ApiResult(Element):
         return self._queryString
     
     def __get(self, prop):
-        return self._soup.osm[prop] if self._isValid and 'osm' in self._soup and prop in self._soup.osm.attrs else None
+        return self._soup.attrs[prop] if self._isValid and prop in self._soup.attrs else None
     
     ### general information
     def version(self):


### PR DESCRIPTION
I was not able to query version of node with the latest modification. It always return None. Here is a small patch that fixed the things for me.