### PR TITLE
pass arbitrary params to Nominatim API

### DIFF
--- a/OSMPythonTools/nominatim.py
+++ b/OSMPythonTools/nominatim.py
@@ -3,14 +3,17 @@ import urllib.parse
 from OSMPythonTools.internal.cacheObject import CacheObject
 
 class Nominatim(CacheObject):
-    def __init__(self, endpoint='https://nominatim.openstreetmap.org/search', **kwargs):
+    def __init__(self, endpoint='https://nominatim.openstreetmap.org/search', params={}, **kwargs):
         super().__init__('nominatim', endpoint, **kwargs)
+        self._params = params
     
     def _queryString(self, query):
         return (query, query)
     
     def _queryRequest(self, endpoint, queryString):
-        return endpoint + '?format=json&q=' + urllib.parse.quote_plus(queryString, safe='')
+        paramsDict = {'format':'json', 'q':queryString, **self._params}
+        queryParams = urllib.parse.urlencode(paramsDict, safe='')
+        return "{}?{}".format(endpoint, queryParams)
     
     def _rawToResult(self, data, queryString):
         return NominatimResult(data, queryString)


### PR DESCRIPTION
This may not be a feature desired by the authors, but I thought it might be helpful to pass other parameters when querying the nominatim API ([Nominatim search API docs](https://wiki.openstreetmap.org/wiki/Nominatim#Search)).