### PR TITLE
add query params to delete operation

### DIFF
--- a/OSMPythonTools/internal/cacheObject.py
+++ b/OSMPythonTools/internal/cacheObject.py
@@ -41,8 +41,9 @@ class CacheObject:
         return result
     
     def deleteQueryFromCache(self, *args, **kwargs):
-        queryString, hashString = self._queryString(*args, **kwargs)
-        filename = self.__cacheDir + '/' + self._prefix + '-' + self.__hash(hashString)
+        queryString, hashString, params = self._queryString(*args, **kwargs)
+        filename = self.__cacheDir + '/' + self._prefix + '-' + self.__hash(
+                   hashString + ('????' + urllib.parse.urlencode(sorted(params.items())) if params else ''))
         if os.path.exists(filename):
             print('[' + self._prefix + '] removing cached data: ' + queryString)
             os.remove(filename)


### PR DESCRIPTION
Looks like `deleteQueryFromCache` should also use `params` argument. Otherwise it raises an error on attempt to clear the cache.