### PR TITLE
Reduce footprint / make dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,15 +171,15 @@ More examples can be found inside the documentation of the modules.
 
 The following modules are available (please click on their names to access further documentation):
 
-* [OSMPythonTools.**Api**](docs/api.md) - Access to the official OSM API
-* [OSMPythonTools.**Data**](docs/data.md) - Collecting, mining, and drawing data from OSM; to be used in combination with the other modules
-* [OSMPythonTools.**Element**](docs/element.md) - Elements are returned by other services, like the OSM API or the Overpass API
-* [OSMPythonTools.**Nominatim**](docs/nominatim.md) - Access to Nominatim, a reverse geocoder
-* [OSMPythonTools.**Overpass**](docs/overpass.md) - Access to the Overpass API
+* [OSMPythonTools.**Api**](https://github.com/mocnik-science/osm-python-tools/blob/master/docs/api.md) - Access to the official OSM API
+* [OSMPythonTools.**Data**](https://github.com/mocnik-science/osm-python-tools/blob/master/docs/data.md) - Collecting, mining, and drawing data from OSM; to be used in combination with the other modules
+* [OSMPythonTools.**Element**](https://github.com/mocnik-science/osm-python-tools/blob/master/docs/element.md) - Elements are returned by other services, like the OSM API or the Overpass API
+* [OSMPythonTools.**Nominatim**](https://github.com/mocnik-science/osm-python-tools/blob/master/docs/nominatim.md) - Access to Nominatim, a reverse geocoder
+* [OSMPythonTools.**Overpass**](https://github.com/mocnik-science/osm-python-tools/blob/master/docs/overpass.md) - Access to the Overpass API
 
-Please refer to the [general remarks](docs/general-remarks.md) page if you have further questions related to `OSMPythonTools` in general or functionality that the several modules have in common.
+Please refer to the [general remarks](https://github.com/mocnik-science/osm-python-tools/blob/master/docs/general-remarks.md) page if you have further questions related to `OSMPythonTools` in general or functionality that the several modules have in common.
 
-**Observe the [breaking changes as included in the version history](version-history.md).**
+**Observe the [breaking changes as included in the version history](https://github.com/mocnik-science/osm-python-tools/blob/master/version-history.md).**
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,20 @@ The python package `OSMPythonTools` provides easy access to [OpenStreetMap (OSM)
 
 ## Installation
 
-To install `OSMPythonTools`, you will need `python3` and `pip` ([How to install pip](https://pip.pypa.io/en/stable/installing/)). Then execute:
+To install `OSMPythonTools`, you will need `python` and `pip` ([How to install pip](https://pip.pypa.io/en/stable/installing/)). Then execute:
 ```bash
 pip install OSMPythonTools
 ```
+
 On some operating systems, `pip` for `python3` is named `pip3`:
 ```bash
 pip3 install OSMPythonTools
+```
+
+To use the built-in data module for easily collecting, mining, and drawing data from OSM, the installation of additional dependencies is required:
+```bash
+pip install OSMPythonTools[all]
+# or: pip3 install OSMPythonTools[all]
 ```
 
 ## Example 1
@@ -187,8 +194,8 @@ Please note that suppressing the messages means that you have to ensure on your 
 
 You can test the package by installing the corresponding dependencies
 ```bash
-pip install OSMPythonTools [test]
-# or: pip3 install OSMPythonTools [test]
+pip install OSMPythonTools[all,test]
+# or: pip3 install OSMPythonTools[all,test]
 ```
 and then running
 ```bash

--- a/docs/data.md
+++ b/docs/data.md
@@ -2,7 +2,10 @@
 
 # Data Tools
 
-The module contains tools for easily collecting, mining, and drawing data from OSM. It is meant to be used in combination with the other modules.
+The module contains tools for easily collecting, mining, and drawing data from OSM. It is meant to be used in combination with the other modules. To use this module, OSMPythonTools must be installed with all optional dependecies:
+```bash
+pip install OSMPythonTools[all]
+```
 
 ## Querying data
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 pkgName='OSMPythonTools'
-pkgVersion='0.3.5'
+pkgVersion='0.4.0'
 pkgUrl='https://github.com/mocnik-science/osm-python-tools'
 
 with open('./OSMPythonTools/__info__.py', 'w') as f:
@@ -17,13 +17,16 @@ setuptools.setup(
         'beautifulsoup4',
         'geojson',
         'lxml',
-        'matplotlib',
-        'numpy',
-        'pandas',
+        'python-dateutil',
         'ujson',
-        'xarray',
     ],
     extras_require={
+        'all': [
+            'matplotlib',
+            'numpy',
+            'pandas',
+            'xarray',
+        ],
         'test': [
             'pytest',
             'pytest-sugar',

--- a/version-history.md
+++ b/version-history.md
@@ -4,6 +4,10 @@
 
 Please note that versions may include breaking changes.
 
+## Version v0.4.0
+
+* [improvement; breaking change] make data module's dependencies optional, to reduce the number of required packages
+
 ## Version v0.3.5
 
 * [improvement] missing geometric information is downloaded when needed


### PR DESCRIPTION
Hi @mocnik-science,
thanks a lot for this very useful python package.

I am using OSMPythonTools in a server context and recognized, that there are some really heavy dependencies: `matplotlib`, `numpy` and `pandas`. Would you mind making these optional, as they are only used by the `data` module?

Here is a comparison of the virtual environment folder (Linux) with and without optional dependencies:

- all requirements: 260 MB | 24 packages
- without `data` requirements: 40 MB | 11 packages

Besides modifying `setup.py`, I did add some documentation where applicable.

Unfortunately I was not able to run the tests. This should be no problem, as there were no changes to the internal code. The output of `pytest --verbose` is:

```
Test session starts (platform: linux, Python 3.11.3, pytest 7.3.1, pytest-sugar 0.9.7)
cachedir: .pytest_cache
rootdir: /home/sta/temp/new
plugins: sugar-0.9.7
collected 0 items

Results (0.01s):