### PR TITLE
Include the option to use a polygon in the Overpass query. 

### DIFF
--- a/OSMPythonTools/overpass.py
+++ b/OSMPythonTools/overpass.py
@@ -10,13 +10,17 @@ from OSMPythonTools.element import Element
 from OSMPythonTools.internal.cacheObject import CacheObject
 from OSMPythonTools.internal.response import Response
 
-def overpassQueryBuilder(area=None, bbox=None, elementType=None, selector=[], conditions=[], since=None, to=None, userid=None, user=None, includeGeometry=False, includeCenter=False, out='body'):
+def overpassQueryBuilder(area=None, bbox=None, polygon= None, elementType=None, selector=[], conditions=[], since=None, to=None, userid=None, user=None, includeGeometry=False, includeCenter=False, out='body'):
     if not elementType:
         OSMPythonTools._raiseException('overpassQueryBuilder', 'Please provide an elementType')
-    if not area and not bbox:
-        OSMPythonTools._raiseException('overpassQueryBuilder', 'Please provide an area or a bounding box')
+    if not area and not bbox and not polygon:
+        OSMPythonTools._raiseException('overpassQueryBuilder', 'Please provide an area or a bounding box or a polygon')
     if area and bbox:
         OSMPythonTools._raiseException('overpassQueryBuilder', 'Please do not provide an area and a bounding box')
+    if area and polygon:
+        OSMPythonTools._raiseException('overpassQueryBuilder', 'Please do not provide an area and a polygon')
+    if bbox and polygon:
+        OSMPythonTools._raiseException('overpassQueryBuilder', 'Please do not provide a bounding box and a polygon')
     if userid and user:
         OSMPythonTools._raiseException('overpassQueryBuilder', 'Please do only provide one of the following: user ID and username')
     if isinstance(area, str) or isinstance(area, Element) or isinstance(area, NominatimResult):
@@ -41,10 +45,11 @@ def overpassQueryBuilder(area=None, bbox=None, elementType=None, selector=[], co
     userRestriction2 = '(user:' + ','.join(map(lambda u: '"' + u + '"', user)) + ')' if user else ''
     searchArea = '(' + 'area.searchArea' + ')' if areaId else ''
     searchBbox = '(' + ','.join(map(str, bbox)) + ')' if bbox else ''
+    searchPolygon = f'(poly:"{polygon}")' if polygon else ''
     conditions = '(if: ' + ' && '.join(map(str, conditions)) + ')' if conditions else ''
     query = ('area(' + str(areaId) + ')->.searchArea;(') if areaId else '('
     for e in elementType:
-        query += e + ''.join(map(lambda x: '[' + x + ']', selector)) + conditions + dateRestriction + userRestriction + userRestriction2 + searchArea + searchBbox + ';'
+        query += e + ''.join(map(lambda x: '[' + x + ']', selector)) + conditions + dateRestriction + userRestriction + userRestriction2 + searchArea + searchBbox + searchPolygon + ';'
     if isinstance(out, str):
         out = [out]
     if includeCenter:


### PR DESCRIPTION
Hi, 

Thanks for your work. I woud like to include a small addition to the package so that a polygon can be passed into the overpass query. This is helpful because some names are not matching between OSM and other libraries, therefore, the coordinates of a region can be used to make the overpass query.  The use of a polygon can be read here: https://dev.overpass-api.de/overpass-doc/en/full_data/polygon.html 

It is a very easy fix so i hope you can include it. 

